### PR TITLE
Fix checkov multiline script

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           INPUT_SKIP_CHECK_FILE: ${{ inputs.skip_check_file }}
         with:
-          cmd: >
+          cmd: |
             if [[ ! -f "${INPUT_SKIP_CHECK_FILE}" ]]; then
               echo "skip_check: []" > ${INPUT_SKIP_CHECK_FILE}
             fi


### PR DESCRIPTION
La différence c'est que `>` ignore les newlines (sauf s'il y en a deux consécutifs), mais que `|` lui ne les ignore pas.