### PR TITLE
Temporally downgrade checkov version

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Checkov action
         id: checkov
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@v12.2404.0
         with:
           directory: ./
           output_format: sarif


### PR DESCRIPTION
On a un problème avec checkov, https://github.com/bridgecrewio/checkov/issues/5251, pour le moment comme il n'y a pas de fix, on downgrade pour utiliser la version 12.2404.0 de checkov-action qui inclu la version 2.3.301 de checkov.