### PR TITLE
Use version before breaking

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Checkov action
         id: checkov
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@v12.2580.0
         with:
           directory: ./
           output_format: sarif


### PR DESCRIPTION
https://github.com/equisoft-devops/terraform-nextgen/actions/runs/6930849506/job/18854401038
>ValueError: Credentials for client are not set

C'est une erreur dans la version 3.1 de checkov, la github action 12.2580.0 possède 3.0.40.